### PR TITLE
Added feature to follow start crop handle

### DIFF
--- a/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
+++ b/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
@@ -8,12 +8,15 @@
 
 import UIKit
 
-public protocol ABVideoRangeSliderDelegate: class {
+@objc public protocol ABVideoRangeSliderDelegate: class {
     func didChangeValue(videoRangeSlider: ABVideoRangeSlider, startTime: Float64, endTime: Float64)
     func indicatorDidChangePosition(videoRangeSlider: ABVideoRangeSlider, position: Float64)
+    
+    @objc optional func sliderGesturesBegan()
+    @objc optional func sliderGesturesEnded()
 }
 
-public class ABVideoRangeSlider: UIView {
+public class ABVideoRangeSlider: UIView, UIGestureRecognizerDelegate {
 
     private enum DragHandleChoice {
         case start
@@ -49,9 +52,11 @@ public class ABVideoRangeSlider: UIView {
     public var maxSpace: Float = 0              // In Seconds
     
     public var isProgressIndicatorSticky: Bool = false
+    public var isProgressIndicatorDraggable: Bool = true
     
     var isUpdatingThumbnails = false
-
+    var isReceivingGesture: Bool = false
+    
     public enum ABTimeViewPosition{
         case top
         case bottom
@@ -75,7 +80,6 @@ public class ABVideoRangeSlider: UIView {
         self.isUserInteractionEnabled = true
 
         // Setup Start Indicator
-
         let startDrag = UIPanGestureRecognizer(target:self,
                                                action: #selector(startDragged(recognizer:)))
 
@@ -174,8 +178,17 @@ public class ABVideoRangeSlider: UIView {
     }
 
     public func updateProgressIndicator(seconds: Float64){
-        self.progressPercentage = self.valueFromSeconds(seconds: Float(seconds))
-        layoutSubviews()
+        if !isReceivingGesture {
+            let endSeconds = secondsFromValue(value: self.endPercentage)
+            
+            if seconds >= endSeconds {
+                self.resetProgressPosition()
+            } else {
+                self.progressPercentage = self.valueFromSeconds(seconds: Float(seconds))
+            }
+
+            layoutSubviews()
+        }
     }
 
     public func setStartIndicatorImage(image: UIImage){
@@ -231,7 +244,6 @@ public class ABVideoRangeSlider: UIView {
 
     public func setStartPosition(seconds: Float){
         self.startPercentage = self.valueFromSeconds(seconds: seconds)
-        self.progressPercentage = self.valueFromSeconds(seconds: seconds)
         layoutSubviews()
     }
 
@@ -241,7 +253,7 @@ public class ABVideoRangeSlider: UIView {
     }
 
     // MARK: - Private functions
-    
+
     // MARK: - Crop Handle Drag Functions
     @objc private func startDragged(recognizer: UIPanGestureRecognizer){
         self.processHandleDrag(
@@ -267,9 +279,10 @@ public class ABVideoRangeSlider: UIView {
         currentPositionPercentage: CGFloat,
         currentIndicator: UIView
         ) {
-        let translation = recognizer.translation(in: self)
         
-        var progressPosition = positionFromValue(value: self.progressPercentage)
+        self.updateGestureStatus(recognizer: recognizer)
+        
+        let translation = recognizer.translation(in: self)
         
         var position: CGFloat = positionFromValue(value: currentPositionPercentage) // self.startPercentage or self.endPercentage
         
@@ -280,57 +293,58 @@ public class ABVideoRangeSlider: UIView {
         if position > self.frame.size.width {
             position = self.frame.size.width
         }
-        
-        if drag == .start {
-            if progressPosition < position || isProgressIndicatorSticky {
-                progressPosition = position
-            }
-        } else {
-            if progressPosition > position {
-                progressPosition = position
-            }
-        }
-        
-        let positionLimit = getPositionLimit(with: drag)
-        
-        position = checkEdgeCasesForPosition(with: position, and: positionLimit, and: drag)
-        
-        let positionLimitMax = getPositionLimitMax(with: drag)
-        
+
+        let positionLimits = getPositionLimits(with: drag)
+        position = checkEdgeCasesForPosition(with: position, and: positionLimits.min, and: drag)
+
         if Float(self.duration) > self.maxSpace && self.maxSpace > 0 {
             if drag == .start {
-                if position < positionLimitMax {
-                    position = positionLimitMax
+                if position < positionLimits.max {
+                    position = positionLimits.max
                 }
             } else {
-                if position > positionLimitMax {
-                    position = positionLimitMax
+                if position > positionLimits.max {
+                    position = positionLimits.max
                 }
             }
         }
         
         recognizer.setTranslation(CGPoint.zero, in: self)
-        progressIndicator.center = CGPoint(x: progressPosition , y: progressIndicator.center.y)
+        
         currentIndicator.center = CGPoint(x: position , y: currentIndicator.center.y)
         
         var percentage = currentIndicator.center.x * 100 / self.frame.width
-        
-        let progressPercentage = progressIndicator.center.x * 100 / self.frame.width
         
         let startSeconds = secondsFromValue(value: self.startPercentage)
         let endSeconds = secondsFromValue(value: self.endPercentage)
         
         self.delegate?.didChangeValue(videoRangeSlider: self, startTime: startSeconds, endTime: endSeconds)
         
-        if self.progressPercentage != progressPercentage {
-            let progressSeconds = secondsFromValue(value: progressPercentage)
-            self.delegate?.indicatorDidChangePosition(videoRangeSlider: self, position: progressSeconds)
-        }
+        var progressPosition: CGFloat = 0.0
         
         if drag == .start {
             self.startPercentage = percentage
         } else {
             self.endPercentage = percentage
+        }
+        
+        if drag == .start {
+            progressPosition = positionFromValue(value: self.startPercentage)
+            
+        } else {
+            if recognizer.state != .ended {
+                progressPosition = positionFromValue(value: self.endPercentage)
+            } else {
+                progressPosition = positionFromValue(value: self.startPercentage)
+            }
+        }
+        
+        progressIndicator.center = CGPoint(x: progressPosition , y: progressIndicator.center.y)
+        let progressPercentage = progressIndicator.center.x * 100 / self.frame.width
+        
+        if self.progressPercentage != progressPercentage {
+            let progressSeconds = secondsFromValue(value: progressPercentage)
+            self.delegate?.indicatorDidChangePosition(videoRangeSlider: self, position: progressSeconds)
         }
         
         self.progressPercentage = progressPercentage
@@ -339,6 +353,12 @@ public class ABVideoRangeSlider: UIView {
     }
     
     func progressDragged(recognizer: UIPanGestureRecognizer){
+        if !isProgressIndicatorDraggable {
+            return
+        }
+        
+        updateGestureStatus(recognizer: recognizer)
+        
         let translation = recognizer.translation(in: self)
 
         let positionLimitStart  = positionFromValue(value: self.startPercentage)
@@ -347,11 +367,11 @@ public class ABVideoRangeSlider: UIView {
         var position = positionFromValue(value: self.progressPercentage)
         position = position + translation.x
 
-        if position < positionLimitStart{
+        if position < positionLimitStart {
             position = positionLimitStart
         }
 
-        if position > positionLimitEnd{
+        if position > positionLimitEnd {
             position = positionLimitEnd
         }
 
@@ -371,6 +391,8 @@ public class ABVideoRangeSlider: UIView {
     }
 
     func viewDragged(recognizer: UIPanGestureRecognizer){
+        updateGestureStatus(recognizer: recognizer)
+        
         let translation = recognizer.translation(in: self)
 
         var progressPosition = positionFromValue(value: self.progressPercentage)
@@ -410,7 +432,7 @@ public class ABVideoRangeSlider: UIView {
 
         if self.progressPercentage != progressPercentage{
             let progressSeconds = secondsFromValue(value: progressPercentage)
-            self.delegate? .indicatorDidChangePosition(videoRangeSlider: self, position: progressSeconds)
+            self.delegate?.indicatorDidChangePosition(videoRangeSlider: self, position: progressSeconds)
         }
 
         self.startPercentage = startPercentage
@@ -426,19 +448,17 @@ public class ABVideoRangeSlider: UIView {
         return position
     }
     
-    private func getPositionLimit(with drag: DragHandleChoice) -> CGFloat {
+    private func getPositionLimits(with drag: DragHandleChoice) -> (min: CGFloat, max: CGFloat) {
         if drag == .start {
-            return positionFromValue(value: self.endPercentage - valueFromSeconds(seconds: self.minSpace))
+            return (
+                positionFromValue(value: self.endPercentage - valueFromSeconds(seconds: self.minSpace)),
+                positionFromValue(value: self.endPercentage - valueFromSeconds(seconds: self.maxSpace))
+            )
         } else {
-            return positionFromValue(value: valueFromSeconds(seconds: self.minSpace) + self.startPercentage)
-        }
-    }
-    
-    private func getPositionLimitMax(with drag: DragHandleChoice) -> CGFloat {
-        if drag == .start {
-            return positionFromValue(value: self.endPercentage - valueFromSeconds(seconds: self.maxSpace))
-        } else {
-            return positionFromValue(value: self.startPercentage + valueFromSeconds(seconds: self.maxSpace))
+            return (
+                positionFromValue(value: self.startPercentage + valueFromSeconds(seconds: self.minSpace)),
+                positionFromValue(value: self.startPercentage + valueFromSeconds(seconds: self.maxSpace))
+            )
         }
     }
     
@@ -470,6 +490,28 @@ public class ABVideoRangeSlider: UIView {
 
     private func valueFromSeconds(seconds: Float) -> CGFloat{
         return CGFloat(seconds * 100) / CGFloat(duration)
+    }
+    
+    private func updateGestureStatus(recognizer: UIGestureRecognizer) {
+        if recognizer.state == .began {
+            
+            self.isReceivingGesture = true
+            self.delegate?.sliderGesturesBegan?()
+            
+        } else if recognizer.state == .ended {
+            
+            self.isReceivingGesture = false
+            self.delegate?.sliderGesturesEnded?()
+        }
+    }
+    
+    private func resetProgressPosition() {
+        self.progressPercentage = self.startPercentage
+        let progressPosition = positionFromValue(value: self.progressPercentage)
+        progressIndicator.center = CGPoint(x: progressPosition , y: progressIndicator.center.y)
+        
+        let startSeconds = secondsFromValue(value: self.progressPercentage)
+        self.delegate?.indicatorDidChangePosition(videoRangeSlider: self, position: startSeconds)
     }
 
     // MARK: -

--- a/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
+++ b/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
@@ -47,7 +47,9 @@ public class ABVideoRangeSlider: UIView {
 
     public var minSpace: Float = 1              // In Seconds
     public var maxSpace: Float = 0              // In Seconds
-
+    
+    public var isProgressIndicatorFollowingStartCropHandle: Bool = false
+    
     var isUpdatingThumbnails = false
 
     public enum ABTimeViewPosition{
@@ -280,7 +282,7 @@ public class ABVideoRangeSlider: UIView {
         }
         
         if drag == .start {
-            if progressPosition < position {
+            if progressPosition < position || isProgressIndicatorFollowingStartCropHandle {
                 progressPosition = position
             }
         } else {

--- a/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
+++ b/ABVideoRangeSlider/Classes/ABVideoRangeSlider.swift
@@ -48,7 +48,7 @@ public class ABVideoRangeSlider: UIView {
     public var minSpace: Float = 1              // In Seconds
     public var maxSpace: Float = 0              // In Seconds
     
-    public var isProgressIndicatorFollowingStartCropHandle: Bool = false
+    public var isProgressIndicatorSticky: Bool = false
     
     var isUpdatingThumbnails = false
 
@@ -282,7 +282,7 @@ public class ABVideoRangeSlider: UIView {
         }
         
         if drag == .start {
-            if progressPosition < position || isProgressIndicatorFollowingStartCropHandle {
+            if progressPosition < position || isProgressIndicatorSticky {
                 progressPosition = position
             }
         } else {

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ If you want to update the position:
 ```Swift
     videoRangeSlider.updateProgressIndicator(seconds: elapsedTimeOfVideo)
 ```
+You can also have the progress indicator be "sticky" follow the start crop indicator when adjusted:
+
+```Swift
+    videoRangeSlider.isProgressIndicatorSticky = true
+```
 
 ## Custom Time Labels
 


### PR DESCRIPTION
I added a feature where, if set to true (false by default), the progress indicator will always follow the start crop handle, like the current version of Instagram. I updated the README to include the feature, and also refactored the startDrag/endDrag code to be more functional (and more DRY).